### PR TITLE
Python3 fix for encrypting

### DIFF
--- a/kmsencryption/__main__.py
+++ b/kmsencryption/__main__.py
@@ -50,7 +50,7 @@ def encrypt(cmk_arn, data, env, profile, prefix):
         source=data,
         key_provider=kms_key_provider)
     result = base64.b64encode(my_ciphertext)
-    click.echo(prefix + result.decode('utf-8')
+    click.echo(prefix + result.decode('utf-8'))
 
 
 @main.command(help='Decrypts a base64-encoded data.')

--- a/kmsencryption/__main__.py
+++ b/kmsencryption/__main__.py
@@ -50,7 +50,7 @@ def encrypt(cmk_arn, data, env, profile, prefix):
         source=data,
         key_provider=kms_key_provider)
     result = base64.b64encode(my_ciphertext)
-    click.echo(prefix + result)
+    click.echo(prefix + result.decode('utf-8')
 
 
 @main.command(help='Decrypts a base64-encoded data.')

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='kms-encryption-toolbox',
-    version='0.0.10',
+    version='0.0.11',
     url='https://github.com/ApplauseOSS/kms-encryption-toolbox',
     license='Applause',
     description='Encryption toolbox to be used with the Amazon Key Management Service for securing your deployment secrets. It encapsulates the aws-encryption-sdk package to expose cmdline actions.',


### PR DESCRIPTION
I was getting
```
Traceback (most recent call last):
  File "../env/bin/kms-encryption", line 11, in <module>
    load_entry_point('kms-encryption-toolbox==0.0.10', 'console_scripts', 'kms-encryption')()
  File "../env/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "../env/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "../env/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "../env/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "../env/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "../env/lib/python3.5/site-packages/kmsencryption/__main__.py", line 53, in encrypt
    click.echo(prefix + result)
TypeError: Can't convert 'bytes' object to str implicitly
```
where prefix is string and result is bytes.