### PR TITLE
Removing the direct dependency on the attrs lib.

### DIFF
--- a/kmsencryption/__main__.py
+++ b/kmsencryption/__main__.py
@@ -1,8 +1,8 @@
 
+from kmsencryption import lib
+
 import click
 import sys
-
-from kmsencryption import lib
 
 
 @click.group(context_settings={"help_option_names": ['-h', '--help']})

--- a/kmsencryption/lib.py
+++ b/kmsencryption/lib.py
@@ -4,6 +4,7 @@ import botocore.session
 import json
 import os
 
+
 def get_key_provider(cmk_arn, profile):
     if cmk_arn:
         kms_kwargs = dict(key_ids=[cmk_arn])

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='kms-encryption-toolbox',
-    version='0.0.14',
+    version='0.0.15',
     url='https://github.com/ApplauseOSS/kms-encryption-toolbox',
     license='Applause',
     description='Encryption toolbox to be used with the Amazon Key Management Service for securing your deployment secrets. It encapsulates the aws-encryption-sdk package to expose cmdline actions.',
@@ -15,7 +15,6 @@ setup(
         'cffi>=1.10.0',
         'aws-encryption-sdk>=1.2.0',
         'click>=6.6',
-        'attrs>=16.3.0,<17.0.0',
         'cryptography>=1.8.1'
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='kms-encryption-toolbox',
-    version='0.0.15',
+    version='0.1.0',
     url='https://github.com/ApplauseOSS/kms-encryption-toolbox',
     license='Applause',
     description='Encryption toolbox to be used with the Amazon Key Management Service for securing your deployment secrets. It encapsulates the aws-encryption-sdk package to expose cmdline actions.',

--- a/test.py
+++ b/test.py
@@ -3,7 +3,6 @@ import aws_encryption_sdk
 kms_key_provider = aws_encryption_sdk.KMSMasterKeyProvider(key_ids=[
    'arn:aws:kms:us-east-1:873559269338:key/1e1a6a81-93e0-4b9a-954b-cc09802bf3ce'
 ])
-import pdb; pdb.set_trace()
 my_plaintext = 'This is some super secret data!  Yup, sure is!'
 
 my_ciphertext, encryptor_header = aws_encryption_sdk.encrypt(
@@ -16,6 +15,6 @@ decrypted_plaintext, decryptor_header = aws_encryption_sdk.decrypt(
     key_provider=kms_key_provider
 )
 
-assert my_plaintext == decrypted_plaintext
+assert my_plaintext == decrypted_plaintext.decode('ascii')
 assert encryptor_header.encryption_context == decryptor_header.encryption_context
 


### PR DESCRIPTION
The direct dependency on the `attrs` lib was never used in the code. Removing, as it's blocking the lib users from upgrading their other libs.

This fixes https://github.com/ApplauseOSS/kms-encryption-toolbox/issues/3