### PR TITLE
Full JSON support for inputs of decrypt-json

### DIFF
--- a/kmsencryption/__main__.py
+++ b/kmsencryption/__main__.py
@@ -32,7 +32,7 @@ def decrypt(data, env, profile, prefix):
 
 @main.command('decrypt-json',
               help='Accepts a JSON map in STDIN (or a file provided in the INPUT parameter) and '
-                   'decrypts base64-encoded map values inside of it.')
+                   'decrypts base64-encoded string values inside of it.')
 @click.argument('input', type=click.File('rb'), default=sys.stdin)
 @click.option('--profile', 'profile', default=None, help='Name of an AWS CLI profile to be used when contacting AWS.')
 @click.option('--prefix', 'prefix', default='',

--- a/kmsencryption/lib.py
+++ b/kmsencryption/lib.py
@@ -1,3 +1,6 @@
+from future.utils import iteritems
+from future.utils import string_types
+
 import aws_encryption_sdk
 import base64
 import botocore.session
@@ -34,38 +37,55 @@ def encrypt_value(data, prefix, key_provider):
 
 
 def encrypt(cmk_arn, data, env, profile, prefix):
-    kms_key_provider = get_key_provider(cmk_arn, profile)
+    key_provider = get_key_provider(cmk_arn, profile)
     if env is not None:
         data = os.getenv(env, data)
     if not data:
         raise ValueError('No data provided via --data or in a variable name passed with --env')
 
-    return encrypt_value(data, prefix, kms_key_provider)
+    return encrypt_value(data, prefix, key_provider)
 
 
 def decrypt(data, env, profile, prefix):
-    kms_key_provider = get_key_provider(None, profile)
+    key_provider = get_key_provider(None, profile)
     if env is not None:
         data = os.getenv(env, data)
     if not data:
         raise ValueError('No data provided via --data or in a variable name passed with --env')
 
-    return decrypt_value(data, prefix, kms_key_provider)
+    return decrypt_value(data, prefix, key_provider)
 
 
-def decrypt_json(input, profile, prefix):
-    kms_key_provider = get_key_provider(None, profile)
-    input_map = json.load(input)
-    output = {}
-    for name, value in input_map.iteritems():
-        output[name] = decrypt_value(value, prefix, kms_key_provider) if value.startswith(prefix) else value
+def decrypt_object(input_object, prefix, key_provider):
+    if not input_object:
+        return input_object
+    if isinstance(input_object, string_types):
+        output = decrypt_value(input_object, prefix, key_provider) if input_object.startswith(prefix) else input_object
+        return output.decode('utf-8')
+    if isinstance(input_object, dict):
+        output = {}
+        for name, value in iteritems(input_object):
+            output[name] = decrypt_object(value, prefix, key_provider)
+        return output
+    if isinstance(input_object, list):
+        output = []
+        for value in input_object:
+            output.append(decrypt_object(value, prefix, key_provider))
+        return output
+    return input_object
+
+
+def decrypt_json(json_input, profile, prefix):
+    key_provider = get_key_provider(None, profile)
+    input_object = json.load(json_input)
+    output = decrypt_object(input_object, prefix, key_provider)
     return json.dumps(output)
 
 
-def encrypt_json(input, cmk_arn, profile, prefix):
-    kms_key_provider = get_key_provider(cmk_arn, profile)
-    input_map = json.load(input)
+def encrypt_json(json_input, cmk_arn, profile, prefix):
+    key_provider = get_key_provider(cmk_arn, profile)
+    input_map = json.load(json_input)
     output = {}
-    for name, value in input_map.iteritems():
-        output[name] = encrypt_value(value, prefix, kms_key_provider)
+    for name, value in iteritems(input_map):
+        output[name] = encrypt_value(value, prefix, key_provider)
     return json.dumps(output)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='kms-encryption-toolbox',
-    version='0.1.0',
+    version='0.1.1',
     url='https://github.com/ApplauseOSS/kms-encryption-toolbox',
     license='Applause',
     description='Encryption toolbox to be used with the Amazon Key Management Service for securing your deployment secrets. It encapsulates the aws-encryption-sdk package to expose cmdline actions.',
@@ -15,7 +15,8 @@ setup(
         'cffi>=1.10.0',
         'aws-encryption-sdk>=1.2.0',
         'click>=6.6',
-        'cryptography>=1.8.1'
+        'cryptography>=1.8.1',
+        'future>=0.16.0'
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Previously, only top-level string maps were supported as inputs of the `decrypt-json` command. This change adds full support for JSON objects, including nested arrays, maps, and all the simple types.