### PR TITLE
Allow for decrypting partial JSON values

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Package is available in the PyPI repo.
     --profile TEXT  Name of an AWS CLI profile to be used when contacting AWS.
     --prefix TEXT   An input prefix to be trimmed from the beginning before a
                     value is decrypted.
+    --allow-partial If partially encrypted string values inside JSON are
+                    allowed. Substrings to decrypt are identified by the
+                    starting prefix and end with a whitespace or end of string.                
     -h, --help      Show this message and exit.
     
     

--- a/kmsencryption/__main__.py
+++ b/kmsencryption/__main__.py
@@ -37,8 +37,11 @@ def decrypt(data, env, profile, prefix):
 @click.option('--profile', 'profile', default=None, help='Name of an AWS CLI profile to be used when contacting AWS.')
 @click.option('--prefix', 'prefix', default='',
               help='An input prefix to be trimmed from the beginning before a value is decrypted.')
-def decrypt_json(input, profile, prefix):
-    click.echo(lib.decrypt_json(input, profile, prefix))
+@click.option('--allow-partial', default=False, is_flag=True,
+              help='If partially encrypted string values inside JSON are allowed. Substrings to decrypt are ' +
+              'identified by the starting prefix and end with a whitespace or end of string.')
+def decrypt_json(input, profile, prefix, allow_partial):
+    click.echo(lib.decrypt_json(input, profile, prefix, allow_partial))
 
 
 @main.command('encrypt-json',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='kms-encryption-toolbox',
-    version='0.1.2',
+    version='0.1.3',
     url='https://github.com/ApplauseOSS/kms-encryption-toolbox',
     license='Applause',
     description='Encryption toolbox to be used with the Amazon Key Management Service for securing your deployment secrets. It encapsulates the aws-encryption-sdk package to expose cmdline actions.',

--- a/test.py
+++ b/test.py
@@ -17,4 +17,3 @@ decrypted_plaintext, decryptor_header = aws_encryption_sdk.decrypt(
 
 assert my_plaintext == decrypted_plaintext.decode('ascii')
 assert encryptor_header.encryption_context == decryptor_header.encryption_context
-


### PR DESCRIPTION
There are cases where you have JSON values like `"some string bla bla bla <encrypted_value>"` which would not be decrypted with the previous version of the library. Adding a new switch `--allow-partial` which also looks inside the string when identifying candidates for decryption. Only one encrypted value per string value is allowed, and it needs to end with a whitespace or end of string.