### PR TITLE
Exclude broken cryptography version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'cffi>=1.10.0',
         'aws-encryption-sdk>=1.2.0,<2.0',
         'click>=6.6',
-        'cryptography>=1.8.1',
+        'cryptography>=1.8.1,!=3.4',
         'future>=0.16.0'
     ],
     entry_points={


### PR DESCRIPTION
Cryptography 3.4 breaks this application.  https://github.com/pyca/cryptography/pull/5758

Fixed in 3.4.1

Relates to https://github.com/ApplauseOSS/kms-encryption-toolbox/issues/14